### PR TITLE
match prettier and eslint to format document without a problem

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
     'generator-star-spacing': 0,
     // allow variables like >> user_id
     'camelcase': 0,
+    'space-before-function-paren': "off",
     'no-trailing-spaces': [
       'error', {'skipBlankLines': true}
     ],

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+    "singleQuote": true,
+    "semi": false,
+    "spaceBeforeFunctionParen": true
+}


### PR DESCRIPTION
On VS Code if you are using prettier to format the doc, ESLint does not accept it with prettier's format. This enables you to just format and ESLint will cause no such problems.