### PR TITLE
Removed remaining global.helpers.js mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,6 @@ Environment variables (add this to git ignore).
 ### `main.js`
 Root app initialization file.
 
-### `global.helpers.js`
-Add global helpers to window object. Yepp globals ... =)
-
 ### How to declare global SCSS variables/mixins etc... ?
 In `/build/utils.js` >> `generateLoaders('sass')`
 

--- a/src/services/base.service.js
+++ b/src/services/base.service.js
@@ -57,7 +57,7 @@ export class BaseService {
     }
   }
 
-  static async getByIdPublic (id = window.required()) {
+  static async getByIdPublic (id) {
     assert.id(id, { required: true })
 
     try {

--- a/src/services/util.js
+++ b/src/services/util.js
@@ -41,7 +41,7 @@ function _getResponseErrorMessage (error) {
 }
 
 /**
- * Create instant, which represent response object
+ * Create instance, which represent response object
  * @param {Object} [data] - custom data
  * @param {Object} [response] - axios response object
  * @param {String} [message] - custom message to display
@@ -57,7 +57,7 @@ export class ResponseWrapper {
 }
 
 /**
- * Create instant, which represent error object
+ * Create instance, which represent error object
  * @param {Object} [error] - axios error object
  * @param {String} [message] - custom message to display
  */


### PR DESCRIPTION
Removed some unused pieces of `src/global.helpers.js` that were left after this commit:

```
commit 2535832b4570b868886155806e799facb39157b5
Author: Sasha Zmts <sa.zmts@gmail.com>
Date:   Mon May 4 23:35:27 2020 +0300

    refact: do async/await; remove redundant flux
```

And small fix for comment ("instant" → "instance")